### PR TITLE
XBVC: Rethink C emitter

### DIFF
--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -2,33 +2,28 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <cobs.h>
-#include <xbvc_core.h>
+#include "cobs.h"
+#include "xbvc_core.h"
+
 union xbvc_msg_union {
-	{% for msg in msgs %}
-	struct x_{{msg.name}} {{msg.name}};
-	{% endfor %}
+{% for msg in msgs %}
+    struct x_{{msg.name}} {{msg.name}};
+{% endfor %}
 };
 
 struct xbvc_message_envelope {
-	uint32_t msg_type;
-	union xbvc_msg_union msg;
-};
-
-static const char *enc_arrays[] = {
-	{% for msg in msgs %}
-	{{msg.encode_array}},
-	{% endfor %}
+    uint32_t msg_type;
+    union xbvc_msg_union msg;
 };
 
 /* Encoder sizes */
 enum enc_sizes {
-	/* '0' is for padding bytes*/
-	E_0  = 0b000,
-	E_8  = 0b001,
-	E_16 = 0b010,
-	E_32 = 0b011,
-	E_64 = 0b100,
+    /* '0' is for padding bytes*/
+    E_0  = 0b000,
+    E_8  = 0b001,
+    E_16 = 0b010,
+    E_32 = 0b011,
+    E_64 = 0b100,
 };
 
 xbvc_data_handler xbvc_platform_read = NULL;
@@ -36,85 +31,105 @@ xbvc_data_handler xbvc_platform_write = NULL;
 
 static int xbvc_encode_bit_vector(void *src, uint8_t *dst, uint8_t rt)
 {
-	int idx = 0;
-	uint64_t val = 0;
+    int idx = 0;
+    uint64_t val = 0;
 
-	switch(rt) {
-	case E_8:
-		*dst = *(uint8_t*)src;
-		return 1;
-	case E_16:
-		val = *(uint16_t*)src;
-		break;
-	case E_32:
-		val = *(uint32_t*)src;
-		break;
-	case E_64:
-		val = *(uint64_t*)src;
-		break;
-	}
+    switch(rt) {
+    case E_8:
+        *dst = *(uint8_t*)src;
+        return 1;
+    case E_16:
+        val = *(uint16_t*)src;
+        break;
+    case E_32:
+        val = *(uint32_t*)src;
+        break;
+    case E_64:
+        val = *(uint64_t*)src;
+        break;
+    }
 
-	do {
-		dst[idx] = val % 128;
-		val /= 128;
+    do {
+        dst[idx] = val % 128;
+        val /= 128;
 
-		if (val > 0)
-			dst[idx] = dst[idx] | 0x80;
-		idx++;
+        if (val > 0)
+            dst[idx] = dst[idx] | 0x80;
+        idx++;
 
-	} while ( val > 0 );
-	return idx;
+    } while ( val > 0 );
+    return idx;
 
 }
 
 static int xbvc_decode_bit_vector(uint8_t *src, void *dst, uint8_t rt)
 {
-	int mul = 1;
-	int idx = 0;
-	uint8_t digit;
+    int mul = 1;
+    int idx = 0;
+    uint8_t digit;
 
-	do {
-		digit = src[idx++];
-		switch (rt) {
-		case E_8:
-			*(uint8_t*)dst += (uint8_t)digit;
-			return 1;
-		case E_16:
-			*(uint16_t*)dst += (uint16_t)((digit & 127) * mul);
-			break;
-		case E_32:
-			*(uint32_t*)dst += (uint32_t)((digit & 127) * mul);
-			break;
-		case E_64:
-			*(uint64_t*)dst += (uint64_t)((digit & 127) * mul);
-			break;
-		}
-		mul *= 128;
-	} while ((digit & 128) != 0);
-	return idx;
+    do {
+        digit = src[idx++];
+        switch (rt) {
+        case E_8:
+            *(uint8_t*)dst += (uint8_t)digit;
+            return 1;
+        case E_16:
+            *(uint16_t*)dst += (uint16_t)((digit & 127) * mul);
+            break;
+        case E_32:
+            *(uint32_t*)dst += (uint32_t)((digit & 127) * mul);
+            break;
+        case E_64:
+            *(uint64_t*)dst += (uint64_t)((digit & 127) * mul);
+            break;
+        }
+        mul *= 128;
+    } while ((digit & 128) != 0);
+    return idx;
 }
+
+{% for msg in msgs %}
+int xbvc_encode_{{msg.name}}(struct x_{{msg.name}} *src, uint8_t *dest,
+                             int max_len)
+{
+    int index = 0;
+{{msg.encoder_body}}
+    return index;
+}
+
+int xbvc_decode_{{msg.name}}(uint8_t *src, struct x_{{msg.name}} *dest,
+                             int max_len)
+{
+    int index = 0;
+{{msg.decoder_body}}
+    return index;
+}
+
+{% endfor %}
+
 
 /* If successful, returns an integer representing how many bytes the
  * target pointer should be incremented by following a succesful bit
  * vecor inflation. Returns -1 on failure */
 static int xbvc_validate_run_type(uint8_t rt)
 {
-	/* TODO: Should we even really encode 8 bit values? */
-	switch (rt) {
-	case E_0:
-		/* Fall through */
-	case E_8:
-		return sizeof(uint8_t);
-	case E_16:
-		return sizeof(uint16_t);
-	case E_32:
-		return sizeof(uint32_t);
-	}
+    /* TODO: Should we even really encode 8 bit values? */
+    switch (rt) {
+    case E_0:
+        /* Fall through */
+    case E_8:
+        return sizeof(uint8_t);
+    case E_16:
+        return sizeof(uint16_t);
+    case E_32:
+        return sizeof(uint32_t);
+    }
 
-	/* We shouldn't get here, but if we
-	 * did, it means that the run type
-	 * was invalid */
-	return -1;
+    /* We shouldn't get here, but if we
+     * did, it means that the run type
+     * was invalid */
+    return -1;
 }
 
 static int xbvc_encode_message(void *msg,
@@ -122,194 +137,141 @@ static int xbvc_encode_message(void *msg,
 			       uint8_t *dst,
 			       size_t dst_len)
 {
-	static uint8_t encbuf[sizeof(struct xbvc_message_envelope) * 2] = {0};
-	uint8_t *bufptr = encbuf;
-	uint8_t *end = bufptr + sizeof(encbuf);
-	uint8_t *rlb = NULL;
-	uint8_t *msgptr = (uint8_t*)msg;
-	int ret, i;
-	size_t size_calc = 0;
+    static uint8_t encbuf[sizeof(struct xbvc_message_envelope) * 2] = {0};
+    uint8_t *bufptr = encbuf;
+    uint8_t *msgptr = (uint8_t*)msg;
+    int ret, enc_res;
+    size_t size_calc = 0;
 
-	/* Make sure we support this message type */
-	if (msg_type > E_MSG_MAX)
-		return -1;
+    /* Make sure we support this message type */
+    if (msg_type > E_MSG_MAX)
+        return -1;
 
-	/* Encode the message type and move the buffer pointer */
-	ret = xbvc_encode_bit_vector(&msg_type, bufptr, E_32);
-	bufptr += ret;
+    /* Encode the message type and move the buffer pointer */
+    ret = xbvc_encode_bit_vector(&msg_type, bufptr, E_32);
+    bufptr += ret;
+    switch (msg_type) {
+	{% for msg in msgs %}
+    case E_MSG_{{msg.name.upper()}}:
+        enc_res = xbvc_encode_{{msg.name}}(
+            (struct x_{{msg.name}}*)msgptr,
+            bufptr, sizeof(encbuf) - ret);
+        break;
+	{% endfor %}
+    }
 
-	/* Get a pointer to the encoder/decoder key array */
-	rlb = (uint8_t*)enc_arrays[msg_type];
+    if (enc_res < 0) {
+        return -2;
+    }
 
-	while(*rlb != 0) {
-		/* Run type */
-		uint8_t rt = (*rlb & 0xF0) >> 5;
+    bufptr += enc_res;
 
-		/* Run length */
-		uint8_t rl = (*rlb & 0x1F);
+    /* Make sure that the encoded message will fit in our
+     * destination buffer, figure out the maximum number of bytes
+     * we will see from the cobs encode */
+    size_calc = (size_t)(bufptr - encbuf);
+    size_calc += size_calc/0xff + 1;
 
-		/* Validate the run type */
-		int inc_amt = xbvc_validate_run_type(rt);
+    if ((size_t)(bufptr - encbuf) > dst_len) {
+        return -4;
+    }
 
-		if (inc_amt < 0)
-			return -2;
+    /* Now that we have the xbv encoded message, cobs encode the
+     * packet into the destination buffer */
+    ret = cobs_encode(encbuf, (size_t)(bufptr - encbuf),
+                      dst);
 
-		/* Loop through the run, encoding each integer along
-		 * the way */
-		for (i = 0; i < rl; i++) {
-			/* Make sure we haven't run off the end of
-			 * the buffer */
-			if (bufptr >= end)
-				return -3;
-
-			/* If this isn't a padding byte, encode it */
-			if (rt != E_0) {
-				ret = xbvc_encode_bit_vector(msgptr, bufptr, rt);
-				bufptr += ret;
-			}
-			msgptr += inc_amt;
-		}
-		rlb++;
-	}
-	
-	/* Make sure that the encoded message will fit in our
-	 * destination buffer, figure out the maximum number of bytes
-	 * we will see from the cobs encode */
-	size_calc = (size_t)(bufptr - encbuf);
-	size_calc += size_calc/0xff + 1;
-	
-	if ((size_t)(bufptr - encbuf) > dst_len)
-		return -4;
-
-	/* Now that we have the xbv encoded message, cobs encode the
-	 * packet into the destination buffer */
-	ret = cobs_encode(encbuf, (size_t)(bufptr - encbuf),
-			  dst);
-
-	if (ret)
-		return ret;
-	else
-		return -5;
+     if (ret) {
+        return ret;
+    } else {
+        return -5;
+    }
 }
 
 static int xbvc_decode_message(uint8_t *ib,
 			       struct xbvc_message_envelope *env,
 			       int len)
 {
-	size_t dec_len;
-	int i, ret;
+    size_t dec_len;
+    int ret, dec_res;
 
-	/* This temporarily holds the data stream after the cobs decode */
-	uint8_t dec_buf[sizeof(struct xbvc_message_envelope) * 2] = {0};
-	uint8_t *dec_ptr = dec_buf;
-	uint8_t *env_ptr = (uint8_t*)env;
-	/* Length of the stream */
-	dec_len =  cobs_decode(ib, len, dec_buf);
+    /* This temporarily holds the data stream after the cobs decode */
+    uint8_t dec_buf[sizeof(struct xbvc_message_envelope) * 2] = {0};
+    uint8_t *dec_ptr = dec_buf;
+    uint8_t *env_ptr = (uint8_t*)env;
+    /* Length of the stream */
+    dec_len =  cobs_decode(ib, len, dec_buf);
 
-	/* Calculate the theoretical end of the stream */
-	uint8_t *end = dec_buf + dec_len;
+    if (!dec_len)
+        return -1;
 
-	if (!dec_len)
-		return -1;
+    /* Decode the envelope type */
+    ret = xbvc_decode_bit_vector(dec_ptr, env_ptr, E_32);
 
-	/* Decode the envelope type */
-	ret = xbvc_decode_bit_vector(dec_ptr, env_ptr, E_32);
+    /* Move the decode pointer and the envelope pointer */
+    dec_ptr += ret;
+    env_ptr += sizeof(env->msg_type);
 
-	/* Move the decode pointer and the envelope pointer */
-	dec_ptr += ret;
-	env_ptr += sizeof(env->msg_type);
+    /* Attempt to grab the encode/decode key array, this will be
+     * known as the run-length byte */
+    if (env->msg_type >= E_MSG_MAX)
+        return -2;
 
-	/* Attempt to grab the encode/decode key array, this will be
-	 * known as the run-length byte */
-	if (env->msg_type >= E_MSG_MAX)
-		return -2;
+    switch (env->msg_type) {
+	{% for msg in msgs %}
+    case E_MSG_{{msg.name.upper()}}:
+        dec_res = xbvc_decode_{{msg.name}}(
+            dec_ptr,
+            (struct x_{{msg.name}}*)env_ptr,
+            sizeof(dec_buf) - ret);
+        break;
+	{% endfor %}
+    }
 
-	uint8_t *rlb = (uint8_t*)enc_arrays[env->msg_type];
+    if (dec_res < 0) {
+        return -2;
+    }
 
-	/* Loop through the decoded buffer and decode each integer in the stream */
-	while (*rlb != 0) {
-		/* Run type */
-		uint8_t rt = (*rlb & 0xF0) >> 5;
-
-		/* Run length */
-		uint8_t rl = (*rlb & 0x1F);
-
-		/* If we've run off the end and the run type isn't
-		 * padding, break */
-		if (dec_ptr >= end && rt != E_0)
-			return -3;
-
-		/* Validate the run type */
-		int inc_amt = xbvc_validate_run_type(rt);
-
-		if (inc_amt < 0)
-			return -4;
-
-		/* Loop through the run, decoding each integer along
-		 * the way */
-		for (i = 0; i < rl; i++) {
-
-
-			/* If this is not a padding byte, decode it */
-			if (rt != E_0) {
-				/* Make sure we haven't run off the end of
-				 * the buffer */
-				if (dec_ptr >= end)
-					return -5;
-				ret = xbvc_decode_bit_vector(dec_ptr, env_ptr, rt);
-				dec_ptr += ret;
-			}
-			env_ptr += inc_amt;
-		}
-
-		/* Grab the next run length byte */
-		rlb++;
-	}
-
-	/* Make sure we decoded the entire message */
-	if (*rlb || dec_ptr < end)
-		return -6;
-
-	/* Glorious victory */
-	return 0;
+    /* Glorious victory */
+    return 0;
 }
 
 /* TODO: Think about moving all autogen sections to their own file */
 static void xbvc_handle_packet(uint8_t *ib, int len)
 {
-	struct xbvc_message_envelope env = {0};
-	int ret;
+    struct xbvc_message_envelope env = {0};
+    int ret;
 
-	ret = xbvc_decode_message(ib, &env, len);
+    ret = xbvc_decode_message(ib, &env, len);
 
-	if (ret)
-		return;
+    if (ret)
+        return;
 
-	switch (env.msg_type) {
+    switch (env.msg_type) {
 	{% for msg in dec_msgs %}
-	case E_MSG_{{msg.name.upper()}}:
-		xbvc_handle_{{msg.name}}((struct x_{{msg.name}} *)&env.msg);
-		break;
-	{% endfor %}
-	};
+    case E_MSG_{{msg.name.upper()}}:
+        xbvc_handle_{{msg.name}}((struct x_{{msg.name}} *)&env.msg);
+        break;
+    {% endfor %}
+    };
 
 }
 
 int xbvc_send(void *msg, uint32_t msg_type)
 {
-	static uint8_t outputbuf[sizeof(struct xbvc_message_envelope) * 2] = {0};
-	int ret;
+    static uint8_t outputbuf[sizeof(struct xbvc_message_envelope) * 2] = {0};
+    int ret;
 
-	ret = xbvc_encode_message(msg, msg_type, outputbuf, sizeof(outputbuf));
+    ret = xbvc_encode_message(msg, msg_type, outputbuf, sizeof(outputbuf));
 
-	if (ret < 0)
-		return ret;
+    if (ret < 0)
+        return ret;
 
-	/* The +1 signifies the '0' packet delimiter */
-	ret = xbvc_platform_write(outputbuf, ret + 1);
+    /* The +1 signifies the '0' packet delimiter */
+    ret = xbvc_platform_write(outputbuf, ret + 1);
 
-	memset(outputbuf, 0x00, sizeof(outputbuf));
-	return ret;
+    memset(outputbuf, 0x00, sizeof(outputbuf));
+    return ret;
 }
 
 /* xbvc initialization function */
@@ -317,45 +279,45 @@ void xbvc_init(void *params, xbvc_data_handler read,
 	       xbvc_data_handler write,
 	       xbvc_platform_init_handler platform_init)
 {
-	xbvc_platform_read = read;
-	xbvc_platform_write = write;
-	platform_init(params);
+    xbvc_platform_read = read;
+    xbvc_platform_write = write;
+    platform_init(params);
 }
 
 /* xbvc main task. */
 void xbvc_run(void)
 {
-	/* Need to leave space at end of input buffer for overhead bytes */
-	static uint8_t inputbuf[sizeof(struct xbvc_message_envelope) * 2] = {0};
-	static uint32_t idx = 0;
+    /* Need to leave space at end of input buffer for overhead bytes */
+    static uint8_t inputbuf[sizeof(struct xbvc_message_envelope) * 2] = {0};
+    static uint32_t idx = 0;
 
-	uint8_t c = 0x00;
-	int res = 0;
+    uint8_t c = 0x00;
+    int res = 0;
 
-	if (xbvc_platform_read == NULL || xbvc_platform_write == NULL)
-		return;
+    if (xbvc_platform_read == NULL || xbvc_platform_write == NULL)
+        return;
 
-	/* Get a single character from the provided interface */
-	res = xbvc_platform_read(&c, 1);
+    /* Get a single character from the provided interface */
+    res = xbvc_platform_read(&c, 1);
 
-	/* Go around again if we didn't receive one */
-	if (res < 1)
-		return;
+    /* Go around again if we didn't receive one */
+    if (res < 1)
+        return;
 
-	/* If the character was a '\x00', this indicates the
-	 * end of a cobs packet, try to decode it */
-	if (c == 0) {
-		xbvc_handle_packet(inputbuf, idx);
-		idx = 0;
-		memset(inputbuf, 0x00, sizeof(inputbuf));
-	} else {
-		inputbuf[idx++] = c;
+    /* If the character was a '\x00', this indicates the
+     * end of a cobs packet, try to decode it */
+    if (c == 0) {
+        xbvc_handle_packet(inputbuf, idx);
+        idx = 0;
+        memset(inputbuf, 0x00, sizeof(inputbuf));
+    } else {
+        inputbuf[idx++] = c;
 
-		/* We're going to overrun the input buffer.
-		 * Start from scratch */
-		if (idx >= sizeof(inputbuf)) {
-			idx = 0;
-			memset(inputbuf, 0x00, sizeof(inputbuf));
-		}
-	}
+        /* We're going to overrun the input buffer.
+         * Start from scratch */
+        if (idx >= sizeof(inputbuf)) {
+            idx = 0;
+            memset(inputbuf, 0x00, sizeof(inputbuf));
+        }
+    }
 }


### PR DESCRIPTION
The C code that was generated previously was very clever with its use
of pointer walking and sorcery.  Unfortunately, the code wasn't very
portable and made a lot of assumptions about things like memory
alignment and sizes of integers.  The new approach uses much more
standard C w/r/t how we decode and encode messages.

Example encode/decode now:
```

int xbvc_encode_set_mono_led(struct x_set_mono_led *src, uint8_t *dest,
                             int max_len)
{
    int index = 0;
    index += xbvc_encode_bit_vector(&src->LedId, &dest[index], E_32);
    if (index >= max_len) {
        return -1;
    }
    index += xbvc_encode_bit_vector(&src->Intensity, &dest[index], E_32);
    if (index >= max_len) {
        return -1;
    }
    index += xbvc_encode_bit_vector(&src->Frequency, &dest[index], E_32);
    if (index >= max_len) {
        return -1;
    }

    return index;
}
```

This has been tested for compilability, but NOT for code correctness (i.e. I don't know if this code actually works).

I'd like to check it in anyway since it's rather large and this shouldn't really be used from source (only packages deployed to PyPi).

@keyme/robotics 