### PR TITLE
C: Allow NULL platform init

### DIFF
--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -264,7 +264,9 @@ void xbvc_init(void *params, xbvc_data_handler read,
 {
     xbvc_platform_read = read;
     xbvc_platform_write = write;
-    platform_init(params);
+    if (platform_init != NULL) {
+        platform_init(params);
+    }
 }
 
 /* xbvc main task. */


### PR DESCRIPTION
Not everyone needs specific platform init, so it should be OK to allow
NULL here.

@keyme/robotics 