### PR TITLE
C: Add default 'weak' handler

### DIFF
--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -219,6 +219,15 @@ static int xbvc_decode_message(uint8_t *ib,
     return 0;
 }
 
+static void _default_handler(void *msg)
+{
+    XBVCTOUCH(msg);
+}
+
+{% for msg in dec_msgs %}
+void xbvc_handle_{{msg.name}}(struct x_{{msg.name}} *msg) __attribute__((weak, alias("_default_handler")));
+{% endfor %}
+
 /* TODO: Think about moving all autogen sections to their own file */
 static void xbvc_handle_packet(uint8_t *ib, int len)
 {

--- a/test/c_tests/test.c
+++ b/test/c_tests/test.c
@@ -33,22 +33,12 @@ void xbvc_handle_get_command(struct x_get_command *msg)
     got_get = true;
 }
 
-void xbvc_handle_get_response(struct x_get_response *msg)
-{
-    XBVCTOUCH(msg);
-}
-
 void xbvc_handle_heartbeat(struct x_heartbeat *msg)
 {
     XBVCTOUCH(msg);
     printf("Got heartbeat!\n");
     assert(msg->Alive == 0xdeadbeef);
     got_heartbeat = true;
-}
-
-void xbvc_handle_ping(struct x_ping *msg)
-{
-    XBVCTOUCH(msg);
 }
 
 void print_get_response(struct x_get_response *msg)


### PR DESCRIPTION
This is GCC only, but it saves a lot of headache when dealing with
messages which you don't want to handle explicitly (useful during
bringup).

This is effectively how MCUs tend to handle interrupt tables.

Tested locally
@keyme/robotics 