### PR TITLE
NIM_EMITTER: Add default discard case to type kind

### DIFF
--- a/XBVC/emitters/templates/nim_interface.jinja2
+++ b/XBVC/emitters/templates/nim_interface.jinja2
@@ -37,6 +37,7 @@ type
     of xm{{msg.pascal_name}}:
       {{msg.name.lower()}}*: {{msg.pascal_name}}Message
 {% endfor %}
+    else: discard
 
 
 {% for msg in messages %}


### PR DESCRIPTION
This appears to be necessary in cases where you have 'gaps' in your
enums. Nim's exhaustiveness checker freaks out and says you haven't
covered all cases.

Tested locally
@keyme/robotics 