### PR TITLE
Fix shutdown

### DIFF
--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -176,7 +176,7 @@ static int xbvc_decode_message(uint8_t *ib,
 			       int len)
 {
     size_t dec_len;
-    int ret, dec_res;
+    int ret, dec_res = 0;
 
     /* This temporarily holds the data stream after the cobs decode */
     uint8_t dec_buf[sizeof(struct xbvc_message_envelope) * 2] = {0};

--- a/XBVC/emitters/templates/nim_interface.jinja2
+++ b/XBVC/emitters/templates/nim_interface.jinja2
@@ -213,6 +213,9 @@ proc start*(ep: XBVCEdgePoint) =
   spawn rxLoop(ep.rxChan.addr, ep.callbacks, ep.responseChan.addr, ep.expectedResponse.addr)
 
 proc stop*(ep: XBVCEdgePoint) =
+  ep.txChan.send(none(byte))
+  # Force a context switch to allow the receiving threads to end
+  sleep(0)
   ep.rxChan.close()
   ep.txChan.close()
 


### PR DESCRIPTION
This is necessary to allow the end user threads to shut down cleanly.  Also fixed a minor issue that can show up in the C emitter when you use -O1

@keyme/robotics 