### PR TITLE
C_EMITTER: Fix enum ID mapping

### DIFF
--- a/XBVC/emitters/c_emitter.py
+++ b/XBVC/emitters/c_emitter.py
@@ -187,8 +187,8 @@ class CEmitter(Emitter):
 
         self.all_msgs = []
 
-        for idx in range(len(self.cs.messages)):
-            self.all_msgs.append(CStructure(self.cs.messages[idx], idx))
+        for idx, msg in enumerate(self.cs.messages):
+            self.all_msgs.append(CStructure(self.cs.messages[idx], msg.msg_id))
 
         self._verify_targets()
 

--- a/test/c_tests/msgs.yaml
+++ b/test/c_tests/msgs.yaml
@@ -31,4 +31,4 @@ heartbeat:
 
 ping:
   - _targets: {host, device}
-  - _id: 3
+  - _id: 0xdeadbeef

--- a/test/c_tests/test.c
+++ b/test/c_tests/test.c
@@ -156,11 +156,18 @@ void test_roundtrip_encoding2(void)
     assert(false);
 }
 
+void test_id_integrity(void)
+{
+    assert(E_MSG_PING == 0xdeadbeef);
+    printf("ID Integrity test passed\n");
+}
+
 
 int main()
 {
     test_encode_round_trip();
     test_roundtrip_encoding();
     test_roundtrip_encoding2();
+    test_id_integrity();
     return 0;
 }


### PR DESCRIPTION
ID's were assumed to follow an incremental scheme.  This is not the
case any more and we need to handle it properly.

Tested with new unit test and on an MCU.

@keyme/robotics 