### PR TITLE
NIM/C: Minor bugfixes

### DIFF
--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -36,8 +36,8 @@ static int xbvc_encode_bit_vector(void *src, uint8_t *dst, uint8_t rt)
 
     switch(rt) {
     case E_8:
-        *dst = *(uint8_t*)src;
-        return 1;
+        val = *(uint8_t*)src;
+        break;
     case E_16:
         val = *(uint16_t*)src;
         break;

--- a/XBVC/emitters/templates/nim_interface.jinja2
+++ b/XBVC/emitters/templates/nim_interface.jinja2
@@ -5,6 +5,7 @@ import threadpool
 import tables
 import rlocks
 import os
+import strformat
 
 const
   ResponsePollMS = 125
@@ -161,7 +162,9 @@ proc rxLoop(ch: ptr Channel[Option[byte]], callbacks: XBVCCallbackTable,
     let msgWrapper = decodeMessage(buf, msgID.get().XBVCMessageType)
 
     if msgWrapper.isNone():
-      echo "Unable to decode message"
+      echo &"Unable to decode message from buffer: {buf}"
+      buf = @[]
+      continue
 
     let msg = msgWrapper.get()
 


### PR DESCRIPTION
This fixes two minor things:

1) The nim decoder now gracefully handles failed decodes and prints out the buffer
2) The C encoder now properly handles U8s (Can't believe I missed that one)

Tested.
@keyme/robotics 