### PR TITLE
NIM: Prevent traceback on restarting an edgepoint

### DIFF
--- a/XBVC/emitters/templates/nim_interface.jinja2
+++ b/XBVC/emitters/templates/nim_interface.jinja2
@@ -219,6 +219,8 @@ proc sendWithResponse*[T](ep: XBVCEdgePoint, msg: T, responseType: XBVCMessageTy
 
 
 proc start*(ep: XBVCEdgePoint) =
+  ep.rxChan = Channel[Option[byte]]()
+  ep.txChan = Channel[Option[byte]]()
   ep.rxChan.open()
   ep.txChan.open()
   spawn rxLoop(ep.rxChan.addr, ep.callbacks, ep.responseChan.addr, ep.expectedResponse.addr)


### PR DESCRIPTION

Once you close a channel, you can't re-open it due to the underlying memory being deallocated.

This creates new channels on each start.

Tested locally
@keyme/robotics 