### PR TITLE
NIM/C: Fix floating point encoding for numbers with leading zero

### DIFF
--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <math.h>
 
+#include <stdio.h>
+
 #include "cobs.h"
 #include "xbvc_core.h"
 
@@ -37,6 +39,17 @@ struct splitfloat {
 };
 
 
+/* NOTE: The splitfloat/combine_float functions store floating point
+   numbers as a signed 32 bit whole number, and an unsigned fractional
+   part.  It is important to note that the fractional part is stored
+   in reverse!  This is done to handle leading zeros gracefully.  For
+   example, 0.07 cannot be easily represented this way as the leading
+   0 will be lost.  Instead we store it as 70, and unpack in reverse
+   when converting back to float.  Alternatively, we COULD store an
+   exponent and divide the fractional part by 10^exp, but then we need
+   to store data on the wire to count the exponent.
+*/
+
 struct splitfloat split_float(float v, int dec_points)
 {
     struct splitfloat result;
@@ -50,12 +63,14 @@ struct splitfloat split_float(float v, int dec_points)
         dec_points = MAX_PRECISION;
     }
 
+    uint32_t mul = 1;
     while (dec_points && v) {
-        result.frac *= 10;
         v *= 10;
-        result.frac += (uint32_t)(v);
+        uint32_t addition = (uint32_t)v * mul;
+        result.frac += addition;
         v = v - (uint32_t)(v);
         dec_points--;
+        mul *= 10;
     }
 
     return result;
@@ -65,10 +80,12 @@ float combine_float(struct splitfloat s)
 {
     float result_whole = (float)s.whole;
     float result_frac = 0;
+    uint32_t mul = 10;
     while (s.frac) {
-        result_frac += (float)(s.frac % 10);
-        result_frac /= 10;
+        float addition = (float)(s.frac % 10) / (float)mul;
+        result_frac += addition;
         s.frac /= 10;
+        mul *= 10;
     }
     if (result_whole < 0) {
         result_frac *= -1.0;

--- a/XBVC/emitters/templates/nim_interface.jinja2
+++ b/XBVC/emitters/templates/nim_interface.jinja2
@@ -63,12 +63,14 @@ proc splitFloat(v: float, precision: int=MaxPrecision): SplitFloat =
 
   precision = max(MaxPrecision, precision)
 
+  var mul = 1
   while precision > 0 and v > 0:
-    result.frac *= 10
     v *= 10
-    result.frac += v.uint32
+    let addition = v.uint32 * mul.uint32
+    result.frac += addition
     v = v - (v.uint32).float
     dec precision
+    mul *= 10
 
 
 proc combineFloat(s: SplitFloat): float =
@@ -76,10 +78,12 @@ proc combineFloat(s: SplitFloat): float =
   var resultFrac = 0.0
   var s = s
 
+  var mul = 10
   while s.frac > 0.uint32:
-    resultFrac += (s.frac mod 10).float
-    resultFrac /= 10
+    let addition = (s.frac mod 10).float / mul.float
+    resultFrac += addition
     s.frac = (s.frac.int / 10.int).uint32
+    mul *= 10
 
   if resultWhole < 0:
     resultFrac *= -1

--- a/test/c_tests/msgs.yaml
+++ b/test/c_tests/msgs.yaml
@@ -24,6 +24,9 @@ messages:
     - Result: s32
     - Bar: u8
     - Version: f32
+    - Version2: f32
+    - Version3: f32
+    - Version4: f32
 
   heartbeat:
     - _targets: {host, device}

--- a/test/c_tests/test.c
+++ b/test/c_tests/test.c
@@ -55,6 +55,9 @@ void print_get_response(struct x_get_response *msg)
     printf("Result: %d\n", msg->Result);
     printf("Bar: 0x%x\n", msg->Bar);
     printf("Version: %f\n", msg->Version);
+    printf("Version2: %f\n", msg->Version2);
+    printf("Version3: %f\n", msg->Version3);
+    printf("Version4: %f\n", msg->Version4);
     printf("-------------------\n");
 
 }
@@ -71,7 +74,7 @@ void test_encode_round_trip(void)
 {
     struct x_get_response msg = {0};
     struct x_get_response decoded_msg = {0};
-    uint8_t encode_buf[32] = {0};
+    uint8_t encode_buf[64] = {0};
 
     msg.Error = 0xdeadbeef;
     msg.Target = 0xF00;
@@ -79,7 +82,10 @@ void test_encode_round_trip(void)
     msg.Foo = 0xa5;
     msg.Result = -8675309;
     msg.Bar = 0xff;
-    msg.Version = 2.5;
+    msg.Version = 2.05;
+    msg.Version2 = -1.0;
+    msg.Version3 = 0.0;
+    msg.Version4 = 123.321;
     print_get_response(&msg);
 
     int enc_len = xbvc_encode_get_response(&msg, encode_buf,

--- a/test/nim_tests/test.nim
+++ b/test/nim_tests/test.nim
@@ -28,7 +28,7 @@ let rsp = GetResponseMessage(error: 123.uint32,
                              foo: 128.uint8,
                              result: -45.int32,
                              bar: 5.uint8,
-                             version: -1.5,
+                             version: 0.07.float32,
                              floatList: [1.1.float32,
                                          2.2.float32,
                                          3.3.float32,
@@ -39,6 +39,8 @@ let encoded = rsp.serialize()
 let decoded = deserializeGetResponse(encoded[1..^1])
 if decoded.isSome():
   let decInternal = decoded.get()
+  echo rsp
+  echo decInternal
   assert decInternal == rsp
   echo "decoded GetResponse successfully"
 else:


### PR DESCRIPTION
0.07 would be encoded as 0.7 due to not taking the leading zero into
account.

@keyme/robotics-engineers 