### PR TITLE
CORE: Clean up base objects

### DIFF
--- a/XBVC/emitters/nim_emitter.py
+++ b/XBVC/emitters/nim_emitter.py
@@ -3,14 +3,31 @@ from XBVC.emitters.EmitterBase import SourceFile, EmitterBase
 
 EMITTER_NAME = 'nim'
 
+_TYPE_MAP = {
+    'f32': 'float32',
+    'f64': 'float64',
+    'u32': 'uint32',
+    's32': 'int32',
+    'u16': 'uint16',
+    's16': 'int16',
+    'u8': 'uint8',
+    's8': 'int8',
+}
+
 
 class Emitter(EmitterBase):
     def __init__(self):
         super().__init__('Nim')
 
+    def _annotate_messages(self):
+        for msg in self.cs.messages:
+            for member in msg.members:
+                member.nim_d_type = _TYPE_MAP[member.d_type]
+
     def generate_source(self, commspec, targets):
         self.cs = commspec
         source_files = []
+        self._annotate_messages()
         source_files.append(self._generate_interface())
 
         return source_files

--- a/XBVC/objects.py
+++ b/XBVC/objects.py
@@ -40,7 +40,19 @@ def pascal_string(st):
     return result
 
 
-class DataMember(object):
+class FlexibleNames:
+    name = ""
+
+    @property
+    def pascal_name(self):
+        return pascal_string(self.name)
+
+    @property
+    def camel_name(self):
+        return camel_string(self.name)
+
+
+class DataMember(FlexibleNames):
     def __init__(self, dm):
         m_tup = list(dm.items())[0]
         self.name = m_tup[0]
@@ -63,27 +75,6 @@ class DataMember(object):
         else:
             self.d_len = 1
 
-    @property
-    def pascal_name(self):
-        return pascal_string(self.name)
-
-    @property
-    def camel_name(self):
-        return camel_string(self.name)
-
-    @property
-    def nim_d_type(self):
-        return {
-            'f32': 'float32',
-            'f64': 'float64',
-            'u32': 'uint32',
-            's32': 'int32',
-            'u16': 'uint16',
-            's16': 'int16',
-            'u8': 'uint8',
-            's8': 'int8',
-        }[self.d_type]
-
     def __str__(self):
         rs = 'Data Member: {}\n'.format(self.name)
         rs += '-Type: {}\n'.format(self.d_type)
@@ -92,7 +83,7 @@ class DataMember(object):
         return rs
 
 
-class Message(object):
+class Message(FlexibleNames):
     def __init__(self, msg, name):
         self._member_list = []
         self.name = name
@@ -119,14 +110,6 @@ class Message(object):
         return self.name
 
     @property
-    def pascal_name(self):
-        return pascal_string(self.name)
-
-    @property
-    def camel_name(self):
-        return camel_string(self.name)
-
-    @property
     def members(self):
         return list(self._member_list)
 
@@ -136,7 +119,7 @@ class Message(object):
         return False
 
 
-class Enum(object):
+class Enum(FlexibleNames):
     def __init__(self, enm, name):
         self.enm_list = enm
         self.name = name
@@ -155,10 +138,6 @@ class Enum(object):
     def prefixed_camel_vals(self):
         return [camel_string('{}_{}'.format(self.value_prefix, x.lower()))
                 for x in self.enm_list]
-
-    @property
-    def pascal_name(self):
-        return pascal_string(self.name)
 
     def __str__(self):
         st = "enum {}:\n".format(self.name)


### PR DESCRIPTION
Two changes here:
1. Move the nim_types stuff into the nim emitter where it belongs
2. Use a mixin to provide camel/pascal names for objects

@keyme/robotics-engineers 