### PR TITLE
HASKELL: Use state monad when encoding and decoding bitvecs

### DIFF
--- a/XBVC/emitters/haskell_emitter.py
+++ b/XBVC/emitters/haskell_emitter.py
@@ -15,45 +15,45 @@ _TYPE_MAP = {
 }
 
 _ENC_MAP = {
-    'f32': 'Bitvec.encodeFloat',
+    'f32': 'Bitvec.encodeFloatS',
     'f64': 'encodeFloat',
-    'u32': 'Bitvec.encode',
-    's32': 'Bitvec.encode',
-    'u16': 'Bitvec.encode',
-    's16': 'Bitvec.encode',
-    'u8': 'Bitvec.encode',
-    's8': 'Bitvec.encode',
+    'u32': 'Bitvec.encodeS',
+    's32': 'Bitvec.encodeS',
+    'u16': 'Bitvec.encodeS',
+    's16': 'Bitvec.encodeS',
+    'u8': 'Bitvec.encodeS',
+    's8': 'Bitvec.encodeS',
 }
 
 _DEC_MAP = {
-    'f32': 'Bitvec.decodeFloat',
+    'f32': 'Bitvec.decodeFloatST',
     'f64': 'decodeFloat',
-    'u32': 'Bitvec.decode',
-    's32': 'Bitvec.decode',
-    'u16': 'Bitvec.decode',
-    's16': 'Bitvec.decode',
-    'u8': 'Bitvec.decode',
-    's8': 'Bitvec.decode',
+    'u32': 'Bitvec.decodeST',
+    's32': 'Bitvec.decodeST',
+    'u16': 'Bitvec.decodeST',
+    's16': 'Bitvec.decodeST',
+    'u8': 'Bitvec.decodeST',
+    's8': 'Bitvec.decodeST',
 }
 
 _LIST_DEC_MAP = {
-    'f32': 'Bitvec.decodeFloatList',
+    'f32': 'Bitvec.decodeFloatListST',
     'f64': 'decodeFloatList',
-    'u32': 'Bitvec.decodeList',
-    's32': 'Bitvec.decodeList',
-    'u16': 'Bitvec.decodeList',
-    's16': 'Bitvec.decodeList',
-    'u8': 'Bitvec.decodeList',
-    's8': 'Bitvec.decodeList',
+    'u32': 'Bitvec.decodeListST',
+    's32': 'Bitvec.decodeListST',
+    'u16': 'Bitvec.decodeListST',
+    's16': 'Bitvec.decodeListST',
+    'u8': 'Bitvec.decodeListST',
+    's8': 'Bitvec.decodeListST',
 }
 
 
 def _gen_decode_string(member):
     if member.d_len == 1:
-        return '{} bs'.format(_DEC_MAP[member.d_type])
+        return '{}'.format(_DEC_MAP[member.d_type])
 
     return (
-        '{} bs {}'
+        '{} {}'
         .format(
             _LIST_DEC_MAP[member.d_type],
             member.d_len
@@ -65,7 +65,7 @@ def _gen_encode_string(member):
     if member.d_len == 1:
         return '{} {}'.format(_ENC_MAP[member.d_type], member.camel_name)
 
-    return ('BS.concat $ {} <$> (take {} {})'
+    return ('mapM_ {} $ take {} {}'
             .format(_ENC_MAP[member.d_type],
                     member.d_len,
                     member.camel_name))

--- a/XBVC/emitters/templates/Bitvec.hs
+++ b/XBVC/emitters/templates/Bitvec.hs
@@ -177,7 +177,7 @@ encodeFloat f = BS.concat [signEnc, wholeEnc, fracEnc]
 -- | Decode an EBV (stored in a bytestring) into a floating point
 -- number and any remaining bytes
 decodeFloat :: BS.ByteString -> Maybe (Float, BS.ByteString)
-decodeFloat bs = runStateT (do
+decodeFloat = runStateT $ do
   signRaw  <- decodeST :: StateT BS.ByteString Maybe Word8
   wholeRaw <- decodeST :: StateT BS.ByteString Maybe Word32
   fracRaw  <- decodeST :: StateT BS.ByteString Maybe Word32
@@ -186,7 +186,7 @@ decodeFloat bs = runStateT (do
       fracDig = (floatify . intDigits) $ toInteger fracRaw
       fracFlt = reconstitute $ zip fracDig magnitudeList'
       result = sm * (wholeFlt + fracFlt) :: Float
-  return result) bs
+  return result
 
 -- | Encodes an integral as an extensible bit vector represented by a bytestring
 encode :: (Integral a) => a -> BS.ByteString

--- a/XBVC/emitters/templates/haskell_data.jinja2
+++ b/XBVC/emitters/templates/haskell_data.jinja2
@@ -4,6 +4,7 @@
 
 module XBVC.Data where
 
+import Control.Monad.State
 import Control.Concurrent
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
@@ -40,17 +41,26 @@ data {{msg.pascal_name}} = {{msg.pascal_name}}
 
 instance Serializable {{msg.pascal_name}} where
   serialize ({{msg.pascal_name}} {{msg.space_sep_member_list}}) =
-    BS.concat [
-    {% for m in msg.members if not m.camel_name in ["randomId", "responseTo"] %}
-    {%if loop.index > 1%}    ,{%else %}     {% endif %} {{m.encode_str}}
-    {% endfor %}
-    ]
+    {%if msg.members|length > 2%}
+    Bitvec.encodeSNew (do
+        {% for m in msg.members if not m.camel_name in ["randomId", "responseTo"] %}
+            {{m.encode_str}}
+        {% endfor %}
+                      )
+    {%else%}
+    BS.empty
+    {%endif%}
 
-  deserialize bs = do
-  {% for m in msg.members if not m.camel_name in ["randomId", "responseTo"] %}
-    ({{m.camel_name}}, bs) <- {{m.decode_str}}
-  {% endfor %}
-    justOnEnd bs $ {{msg.pascal_name}} {{msg.space_sep_member_list}}
+  deserialize bs =
+    {%if msg.members|length > 2%}
+    Bitvec.decodeSTUntilEmpty (do
+    {% for m in msg.members if not m.camel_name in ["randomId", "responseTo"] %}
+      {{m.camel_name}} <- {{m.decode_str}}
+    {% endfor %}
+      return $ {{msg.pascal_name}} {{msg.space_sep_member_list}}) bs
+    {%else%}
+    Bitvec.justOnEnd bs {{msg.pascal_name}}
+    {%endif%}
 
 instance XBVCType {{msg.pascal_name}} where
     xbvcPacket = makePacketInstance {{msg.msg_id}}
@@ -65,10 +75,6 @@ data Dispatcher = Dispatcher
   }
 
 {# Below this is the core code #}
-justOnEnd :: BS.ByteString -> a -> Maybe a
-justOnEnd bs a = if BS.null bs
-                    then Just a
-                    else Nothing
 
 class Show a => Serializable a where
     serialize :: a -> BS.ByteString
@@ -122,11 +128,13 @@ instance Serializable XBVCPacket where
                                            , d
                                            ]
 
-    deserialize bs = do
-        (mType, bs) <- Bitvec.decode bs
-        (mID, bs) <- Bitvec.decode bs
-        (rID, bs) <- Bitvec.decode bs
-        return $ Packet mType mID rID bs
+    deserialize bs =
+        let result = runStateT (do
+                mType <- Bitvec.decodeST
+                mID   <- Bitvec.decodeST
+                rID   <- Bitvec.decodeST
+                return $ Packet mType mID rID) bs in
+            fst <$> result <*> (snd <$> result)
 
 type ResponseMap = Map.Map Int (MVar (Maybe XBVCPacket))
 


### PR DESCRIPTION
Moved bitvec to use State and StateT monads to clean up encoding and decoding. Also made an export list for bitvec.

Generated code from this and it compiles and runs.

@keyme/control-systems-engineers 