### PR TITLE
HASKELL: Add more debug info for unmatched messages

### DIFF
--- a/XBVC/emitters/templates/Cobs.hs
+++ b/XBVC/emitters/templates/Cobs.hs
@@ -62,7 +62,7 @@ decode bs =
         -- after the zero then the encoding is not correct
         (Just (0, tl)) -> if BS.null tl
             then Right BS.empty
-            else Left (errorMsg "Found non-empty ByteString after 0" tl)
+            else Left (errorMsg "Found non-empty ByteString after 0" bs)
         -- If the next value isn't zero it is the number of
         -- bytes until the next zero
         (Just (h, tl)) ->

--- a/XBVC/emitters/templates/haskell_data.jinja2
+++ b/XBVC/emitters/templates/haskell_data.jinja2
@@ -98,7 +98,7 @@ call dispatcher (Packet mType mID _ pL) =
   {% for msg in messages %}
     {{msg.msg_id}} -> call' {{msg.camel_name}}
   {% endfor %}
-    _    -> putStrLn "Unknown message type tried to be dispatched"
+    n    -> putStrLn $ "Unknown message type tried to be dispatched: " ++ (show n)
   where
     call' :: Serializable a
           => (Dispatcher -> (IORef (Int -> a -> IO ())))


### PR DESCRIPTION
In Cobs showing the remaining bytestring was confusing so now showing original bytestring in decode error message. The second change shows what the message ID is that failed to decode for debugging purposes. 

@keyme/control-systems-engineers 