### PR TITLE
HASKELL: Move XBVC send functions to use channels with bool return

### DIFF
--- a/XBVC/emitters/templates/haskell_core.jinja2
+++ b/XBVC/emitters/templates/haskell_core.jinja2
@@ -14,6 +14,9 @@ import Data.Word
 import System.Random
 import qualified Data.Map as Map
 
+
+type WriteChannel = BS.ByteString -> IO Bool
+
 stopByte :: Word8
 stopByte = 0
 
@@ -43,16 +46,16 @@ newXbvcDispatcher = do
 
 
 xbvcSend :: XBVCType a
-         => (BS.ByteString -> IO ())
+         => WriteChannel
          -> a
          -> Maybe Int
-         -> IO ()
+         -> IO Bool
 xbvcSend serialChannel msg rID = do
     packet <- xbvcPacket msg rID
     serialChannel $ serialize packet
 
 xbvcSendWithResponse :: (XBVCType a, XBVCType b)
-                     => (BS.ByteString -> IO ())
+                     => WriteChannel
                      -> XBVCDispatcher
                      -> a
                      -> Maybe Int
@@ -63,11 +66,14 @@ xbvcSendWithResponse sendChannel dispatcher msg rID = do
     let bs = serialize msg
     empMsg <- newEmptyMVar
     modifyMVar_ respMap (return . Map.insert idKey empMsg)
-    sendChannel $ Cobs.encode bs
-    respMsg <- takeMVar empMsg
-    modifyMVar_ respMap (return . Map.delete idKey)
-    let mPayLoad = payLoad <$> respMsg
-    return $ mPayLoad >>= deserialize
+    sent <- sendChannel $ Cobs.encode bs
+    case sent of
+        False -> return Nothing
+        True -> do
+            respMsg <- takeMVar empMsg
+            modifyMVar_ respMap (return . Map.delete idKey)
+            let mPayLoad = payLoad <$> respMsg
+            return $ mPayLoad >>= deserialize
     where
         respMap = responseMap dispatcher
 

--- a/XBVC/emitters/templates/haskell_core.jinja2
+++ b/XBVC/emitters/templates/haskell_core.jinja2
@@ -67,13 +67,15 @@ xbvcSendWithResponse sendChannel dispatcher msg rID = do
     empMsg <- newEmptyMVar
     modifyMVar_ respMap (return . Map.insert idKey empMsg)
     sent <- sendChannel $ Cobs.encode bs
-    case sent of
+    resp <- case sent of
         False -> return Nothing
         True -> do
             respMsg <- takeMVar empMsg
-            modifyMVar_ respMap (return . Map.delete idKey)
+
             let mPayLoad = payLoad <$> respMsg
             return $ mPayLoad >>= deserialize
+    modifyMVar_ respMap (return . Map.delete idKey)
+    return resp
     where
         respMap = responseMap dispatcher
 


### PR DESCRIPTION
Moves xbvcSend to return a bool for whether it sent successfully and allows an early failure in  xbvcSendWithResponse if the original message fails to send. (If someone were to use this and had a non-blocking send they could just send back a True always)

Works with the changes I made with IO2. 

@keyme/control-systems-engineers 