### PR TITLE
HASKELL: Fix xbvcSend to use COBS encoding

### DIFF
--- a/XBVC/emitters/templates/haskell_core.jinja2
+++ b/XBVC/emitters/templates/haskell_core.jinja2
@@ -51,7 +51,7 @@ xbvcSend :: XBVCType a
          -> IO Bool
 xbvcSend serialChannel msg rID = do
     packet <- xbvcPacket msg rID
-    serialChannel $ serialize packet
+    serialChannel $ Cobs.encode $ serialize packet
 
 xbvcSendWithResponse :: (XBVCType a, XBVCType b)
                      => WriteChannel


### PR DESCRIPTION
Forgot to encode the stand alone send messages. Since we don't get a response we didn't notice they weren't going through if we even have any right now in IO2. 

My branch that needs to send a message works with this change.

@keyme/control-systems-engineers 