### PR TITLE
C|HASKELL: For C and Haskell add support to optionally send decode errors

### DIFF
--- a/XBVC/emitters/templates/c_header.jinja2
+++ b/XBVC/emitters/templates/c_header.jinja2
@@ -42,6 +42,7 @@ struct x_{{msg.name}} {
 {% for p in prototypes %}
 {{p}};
 {% endfor %}
+void xbvc_handle_decode_error_found();
 
 /* Platform handler prototypes */
 typedef int (*xbvc_data_handler)(uint8_t *, int);

--- a/XBVC/emitters/templates/c_interface.jinja2
+++ b/XBVC/emitters/templates/c_interface.jinja2
@@ -329,6 +329,7 @@ static void _default_handler(void *msg)
 {% for msg in dec_msgs %}
 void xbvc_handle_{{msg.name}}(struct x_{{msg.name}} *msg) __attribute__((weak, alias("_default_handler")));
 {% endfor %}
+void xbvc_handle_decode_error_found() __attribute__((weak, alias("_default_handler")));
 
 /* TODO: Think about moving all autogen sections to their own file */
 static void xbvc_handle_packet(uint8_t *ib, int len)
@@ -339,7 +340,7 @@ static void xbvc_handle_packet(uint8_t *ib, int len)
     ret = xbvc_decode_message(ib, &env, len);
 
     if (ret)
-        return;
+        xbvc_handle_decode_error_found();
 
     switch (env.msg_type) {
 	{% for msg in dec_msgs %}

--- a/XBVC/emitters/templates/haskell_core.jinja2
+++ b/XBVC/emitters/templates/haskell_core.jinja2
@@ -24,11 +24,13 @@ newDispatcher = do
   {% for msg in messages %}
     {{msg.camel_name}} <- newIORef $ standIn "{{msg.camel_name}}"
   {% endfor %}
+    decodeErrorFound <- newIORef $ return ()
 
     return $ Dispatcher {
   {% for line in msg_name_list %}
         {{line}}
   {% endfor %}
+        , decodeErrorFound
     }
     where
         standIn str _ msg = do
@@ -95,6 +97,14 @@ dispatch dispatcher packet =
             putMVar (responseMap dispatcher) responses
 
 
+decodePacket :: BS.ByteString -> Either String XBVCPacket
+decodePacket bs = case Cobs.decode bs of
+                    Left err -> Left err
+                    Right uncobs -> case deserialize uncobs of
+                        Nothing -> Left "Bitvec decode error"
+                        Just pkt -> Right pkt
+
+
 processData :: BS.ByteString
        -> XBVCDispatcher
        -> IO (BS.ByteString)
@@ -102,15 +112,13 @@ processData pkt dispatcher = do
   case frameEnd of
     False -> return pkt
     True -> do
-      case Cobs.decode pkt of
-        Left err -> do
-          putStrLn err
-          return BS.empty
-        Right bitvec -> do
-          case deserialize bitvec of
-            Nothing -> putStrLn "Decode error"
-            Just packet -> dispatch dispatcher packet
-          return BS.empty
+        case decodePacket pkt of
+            Left err -> do
+                putStrLn err
+                decodeCB <- readIORef $ decodeErrorFound $ callbacks dispatcher
+                decodeCB
+            Right packet -> dispatch dispatcher packet
+        return BS.empty
   where
     frameEnd = if BS.null pkt
                then False

--- a/XBVC/emitters/templates/haskell_data.jinja2
+++ b/XBVC/emitters/templates/haskell_data.jinja2
@@ -71,6 +71,7 @@ data Dispatcher = Dispatcher
   {% for msg in messages %}
     {%if loop.index > 1%}  ,{%else %}   {% endif %} {{msg.camel_name}} :: (IORef (Int -> {{msg.pascal_name}} -> IO ()))
   {% endfor %}
+  , decodeErrorFound :: IORef (IO ())
   }
 
 {# Below this is the core code #}
@@ -134,7 +135,7 @@ addCallbackWithStateAndContext msgType func state ctx dispatcher = writeIORef (m
   where
     func' = \i m -> do
       modifyMVar_ state $ \stateLocal -> func i m stateLocal ctx
- 
+
 
 data XBVCPacket = Packet
                 { msgType :: Int

--- a/XBVC/objects.py
+++ b/XBVC/objects.py
@@ -125,7 +125,7 @@ class Message(FlexibleNames):
             elif k == '_decoders':
                 self.decoders = v
             elif k == '_id':
-               self.msg_id = v
+                self.msg_id = v
             else:
                 self._member_list.append(DataMember(m))
 


### PR DESCRIPTION
Added support for sending and receiving a "decode_error" message by default. Leaves a stub for a function called when a decode error happens. It doesn't actually send the message by default since it doesn't always make sense (in our use case sending decode errors down to the firmware seems pretty pointless) unless in the future we wanted to incorporate it into some sort of ack system. 

This is mostly for debugging so we can get an idea of how often messages fail to decode on the firmware. Tested in IO2 and working. 

Let me know what you think. 

@keyme/control-systems-engineers 