### PR TITLE
HASKELL: Make maps strict

### DIFF
--- a/XBVC/emitters/templates/haskell_core.jinja2
+++ b/XBVC/emitters/templates/haskell_core.jinja2
@@ -11,7 +11,7 @@ import Control.Concurrent
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Word
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import System.Timeout
 import Data.Maybe
 

--- a/XBVC/emitters/templates/haskell_data.jinja2
+++ b/XBVC/emitters/templates/haskell_data.jinja2
@@ -7,7 +7,7 @@ module XBVC.Data where
 import Control.Monad.State
 import Control.Concurrent
 import qualified Data.ByteString as BS
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.IORef
 import Data.Word
 import Data.Maybe


### PR DESCRIPTION
This is to potentially curb memory issues. Compiles with the IO2 project. 

@keyme/control-systems-engineers 