### PR TITLE
HASKELL: Make modules strict

### DIFF
--- a/XBVC/emitters/templates/haskell_core.jinja2
+++ b/XBVC/emitters/templates/haskell_core.jinja2
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE Strict #-}
 
 module XBVC where
 

--- a/XBVC/emitters/templates/haskell_data.jinja2
+++ b/XBVC/emitters/templates/haskell_data.jinja2
@@ -1,6 +1,7 @@
 -- Shadowing gives the clearest expressing of our generated deserializers
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE Strict #-}
 
 module XBVC.Data where
 


### PR DESCRIPTION
This ensures that firmware designs that require streaming with little
to no guarantee that a value will ever be used do not grow memory
indefinitely

Currently testing
@keyme/control-systems-engineers 